### PR TITLE
Filtering out the "$" while generating telegram_api.jl

### DIFF
--- a/extras/tg_scrape.jl
+++ b/extras/tg_scrape.jl
@@ -74,15 +74,17 @@ function process_table(x, methods, io)
         print(cio, "\n")
     end
 
+    takeclean(input) = replace(strip(String(take!(input))), '$' => "D")
+    
     if isrequired
         print(io, "# Required arguments\n")
-        print(io, strip(String(take!(required))))
+        print(io, takeclean(required))
         print(io, "\n\n")
     end
 
     if isoptional
         print(io, "# Optional arguments\n")
-        print(io, strip(String(take!(optional))))
+        print(io, takeclean(optional))
         print(io, "\n")
     end
 


### PR DESCRIPTION
I identified an issue where the precompilation process gets stuck due to an unescaped dollar sign ($) in the generated telegram_api.jl file. The root cause appears to be the introduction of a dollar sign in the latest version of the Telegram Bot API description: https://core.telegram.org/bots/api
Here I added filter where the dollar sign being replaced with "D," leading to "USD" instead of the "US$".
